### PR TITLE
Correcting build instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To invoke the server, you can run it as follows:
 You can compile the system with cargo:
 
 ```shell
-cargo compile --release
+cargo build --release
 ```
 
 ## Running with docker-compose


### PR DESCRIPTION
Correcting the compilation instructions as 'cargo compile' is not a valid cargo command.